### PR TITLE
feat: initial addon skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 - First Version
+- Initial skeleton of Spectrum Loot Helper addon.
+- Basic UI frame toggled with `/slh`.
+- Database and officer check stubs.
+- Introduced data sync module to share roll counts across the raid.
+- Use addon namespace to avoid polluting the global table.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Spectrum Loot Helper
+
+Spectrum Loot Helper tracks Best-in-Slot roll counts for the Spectrum Federation guild.
+
+## Installation via WoWUP
+
+1. Open WoWUP.
+2. Choose **Addons** > **Install from URL**.
+3. Enter the GitHub repository URL for this project.
+4. WoWUP downloads the addon and places it in your addons directory.
+
+## Usage
+
+- Use `/slh` in-game to toggle the addon window.
+- Officer rank threshold can be edited in `Core.lua` via `OFFICER_RANK`.
+- Roll count changes automatically sync with other raid members.
+
+## Development
+
+Source code resides in the `SpectrumLootHelper` folder. The addon is organized into
+separate Lua files for core logic, data syncing, and UI.

--- a/SpectrumLootHelper/Core.lua
+++ b/SpectrumLootHelper/Core.lua
@@ -1,0 +1,53 @@
+local ADDON_NAME, SLH = ...
+
+SLH.version = "0.1.0"
+SLH.OFFICER_RANK = 2 -- configurable officer rank threshold
+
+-- Initialize saved variables and basic database
+function SLH:Init()
+    SpectrumLootHelperDB = SpectrumLootHelperDB or { rolls = {}, log = {} }
+    self.db = SpectrumLootHelperDB
+    if self.Sync then
+        self.Sync:Request()
+    end
+end
+
+-- Determine if the given unit is an officer in Spectrum Federation
+function SLH:IsOfficer(unit)
+    unit = unit or "player"
+    local guild, _, rankIndex = GetGuildInfo(unit)
+    return guild == "Spectrum Federation" and rankIndex and rankIndex <= self.OFFICER_RANK
+end
+
+-- Adjust a player's roll count and record the change
+function SLH:AdjustRoll(playerName, delta, officer)
+    local current = self.db.rolls[playerName] or 0
+    local newValue = math.max(0, current + delta)
+    self.db.rolls[playerName] = newValue
+    table.insert(self.db.log, {
+        time = GetServerTime(),
+        player = playerName,
+        officer = officer,
+        value = newValue,
+    })
+    if self.Sync then
+        self.Sync:Broadcast()
+    end
+end
+
+-- Event handling
+local frame = CreateFrame("Frame")
+frame:RegisterEvent("ADDON_LOADED")
+frame:SetScript("OnEvent", function(_, event, addon)
+    if event == "ADDON_LOADED" and addon == ADDON_NAME then
+        SLH:Init()
+        print("|cff00ff00Spectrum Loot Helper loaded|r")
+    end
+end)
+
+-- Simple slash command to toggle the UI
+SLASH_SPECTRUMLOOTHELPER1 = "/slh"
+SlashCmdList["SPECTRUMLOOTHELPER"] = function()
+    local f = SLH:CreateMainFrame()
+    if f:IsShown() then f:Hide() else f:Show() end
+end

--- a/SpectrumLootHelper/SpectrumLootHelper.toc
+++ b/SpectrumLootHelper/SpectrumLootHelper.toc
@@ -1,0 +1,10 @@
+## Interface: 100207
+## Title: Spectrum Loot Helper
+## Notes: Track Best-in-Slot rolls for Spectrum Federation
+## Author: Spectrum Federation
+## Version: 0.1.0
+## SavedVariables: SpectrumLootHelperDB
+
+Core.lua
+Sync.lua
+UI.lua

--- a/SpectrumLootHelper/Sync.lua
+++ b/SpectrumLootHelper/Sync.lua
@@ -1,0 +1,51 @@
+local ADDON_NAME, SLH = ...
+
+SLH.Sync = {
+    prefix = "SLH_SYNC",
+}
+
+-- Serialize the current database into a compact string
+function SLH.Sync:Serialize()
+    if not SLH.db or not SLH.db.rolls then return "" end
+    local parts = {}
+    for player, value in pairs(SLH.db.rolls) do
+        table.insert(parts, player .. "=" .. value)
+    end
+    return table.concat(parts, ";")
+end
+
+-- Apply received data to the local database
+function SLH.Sync:Deserialize(data)
+    if type(data) ~= "string" or data == "" then return end
+    for entry in string.gmatch(data, "([^;]+)") do
+        local name, value = entry:match("([^=]+)=(%d+)")
+        if name and value then
+            SLH.db.rolls[name] = tonumber(value)
+        end
+    end
+end
+
+-- Broadcast the full database to the raid group
+function SLH.Sync:Broadcast()
+    local payload = self:Serialize()
+    if payload ~= "" then
+        C_ChatInfo.SendAddonMessage(self.prefix, payload, "RAID")
+    end
+end
+
+-- Request a sync from other raid members
+function SLH.Sync:Request()
+    C_ChatInfo.SendAddonMessage(self.prefix, "REQUEST", "RAID")
+end
+
+C_ChatInfo.RegisterAddonMessagePrefix(SLH.Sync.prefix)
+local frame = CreateFrame("Frame")
+frame:RegisterEvent("CHAT_MSG_ADDON")
+frame:SetScript("OnEvent", function(_, _, prefix, message, channel, sender)
+    if prefix ~= SLH.Sync.prefix then return end
+    if message == "REQUEST" and SLH:IsOfficer("player") then
+        SLH.Sync:Broadcast()
+    else
+        SLH.Sync:Deserialize(message)
+    end
+end)

--- a/SpectrumLootHelper/UI.lua
+++ b/SpectrumLootHelper/UI.lua
@@ -1,0 +1,19 @@
+local ADDON_NAME, SLH = ...
+
+-- Create a very small frame that can be toggled with /slh
+function SLH:CreateMainFrame()
+    if self.frame then return self.frame end
+
+    local frame = CreateFrame("Frame", "SpectrumLootHelperFrame", UIParent, "BackdropTemplate")
+    frame:SetSize(200, 80)
+    frame:SetPoint("CENTER")
+    frame:SetBackdrop({ bgFile = "Interface/Tooltips/UI-Tooltip-Background" })
+    frame:SetBackdropColor(0, 0, 0, 0.7)
+
+    local title = frame:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    title:SetPoint("TOP", 0, -10)
+    title:SetText("Spectrum Loot Helper")
+
+    self.frame = frame
+    return frame
+end

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Spectrum Loot Helper
+
+Spectrum Loot Helper manages Best-in-Slot roll counts and keeps a synchronized log
+among Spectrum Federation guild members. Data changes broadcast to the raid so
+every member stays up to date.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,3 @@
+site_name: Spectrum Loot Helper
+nav:
+  - Home: index.md


### PR DESCRIPTION
## Summary
- sync roll counts across the raid via new `Sync.lua` module and addon messages
- request remote data on initialization and broadcast updates after roll adjustments
- document automatic synchronization and update addon manifest

## Testing
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.0.35 8080])*
- `apt-get install -y lua5.1` *(fails: Unable to locate package lua5.1)*
- `find SpectrumLootHelper -name '*.lua' -print -exec luac -p {} \;` *(fails: 'luac': No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689783a8073c8324997e9b970b1218dc