### PR TITLE
Ensure addon options appear in settings menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.3 - Options category visible
+- Registered addon options with the modern Settings API so it appears under Options > AddOns.
+
 ## 0.1.2 - Root addon folder
 - Moved addon `.toc` and Lua files to the repository root so the game detects the addon when cloned.
 

--- a/Core.lua
+++ b/Core.lua
@@ -1,6 +1,6 @@
 local ADDON_NAME, SLH = ...
 
-SLH.version = "0.1.2"
+SLH.version = "0.1.3"
 SLH.OFFICER_RANK = 2 -- configurable officer rank threshold
 
 -- Initialize saved variables and basic database

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ directory contains the addon's `.toc` and Lua files.
 - Use `/slh` in-game to toggle the addon window.
 - Officer rank threshold can be edited in `Core.lua` via `OFFICER_RANK`.
 - Roll count changes automatically sync with other raid members.
-- In the Blizzard Interface Options, enable **Outside Raid** to use the addon while not in a raid group.
+- In-game, open **Options > AddOns > Spectrum Loot Helper** and enable **Outside Raid** to use the addon while not in a raid group.
 
 ## Development
 

--- a/SpectrumLootTool.toc
+++ b/SpectrumLootTool.toc
@@ -2,7 +2,7 @@
 ## Title: Spectrum Loot Helper
 ## Notes: Track Best-in-Slot rolls for Spectrum Federation
 ## Author: Spectrum Federation
-## Version: 0.1.2
+## Version: 0.1.3
 ## SavedVariables: SpectrumLootHelperDB
 
 Core.lua

--- a/UI.lua
+++ b/UI.lua
@@ -34,5 +34,10 @@ function SLH:CreateOptions()
     end)
 
     self.optionsPanel = panel
-    InterfaceOptions_AddCategory(panel)
+    if Settings and Settings.RegisterCanvasLayoutCategory then
+        local category = Settings.RegisterCanvasLayoutCategory(panel, panel.name, panel.name)
+        Settings.RegisterAddOnCategory(category)
+    else
+        InterfaceOptions_AddCategory(panel)
+    end
 end


### PR DESCRIPTION
## Summary
- Register addon options with Dragonflight Settings API fallback to old interface
- Bump addon version to 0.1.3 and document how to open options panel

## Testing
- `luac -p Core.lua UI.lua Sync.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897e7fd3c308324a5ac37f801d35586