### PR TITLE
Ensure UI toggles correctly outside raids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.4 - Conditional frame visibility
+- Main UI frame hides only during combat or when outside raids without the override setting.
+
 ## 0.1.3 - Options category visible
 - Registered addon options with the modern Settings API so it appears under Options > AddOns.
 

--- a/Core.lua
+++ b/Core.lua
@@ -1,6 +1,6 @@
 local ADDON_NAME, SLH = ...
 
-SLH.version = "0.1.3"
+SLH.version = "0.1.4"
 SLH.OFFICER_RANK = 2 -- configurable officer rank threshold
 
 -- Initialize saved variables and basic database
@@ -54,14 +54,21 @@ end
 local frame = CreateFrame("Frame")
 frame:RegisterEvent("ADDON_LOADED")
 frame:RegisterEvent("PLAYER_REGEN_DISABLED")
+frame:RegisterEvent("PLAYER_REGEN_ENABLED")
 frame:RegisterEvent("GROUP_ROSTER_UPDATE")
 frame:SetScript("OnEvent", function(_, event, arg1)
     if event == "ADDON_LOADED" and arg1 == ADDON_NAME then
         SLH:Init()
+        local f = SLH:CreateMainFrame()
+        if SLH:IsEnabled() then f:Show() else f:Hide() end
         print("|cff00ff00Spectrum Loot Helper loaded|r")
-    elseif event == "PLAYER_REGEN_DISABLED" or event == "GROUP_ROSTER_UPDATE" then
-        if SLH.frame and not SLH:IsEnabled() then
-            SLH.frame:Hide()
+    elseif event == "PLAYER_REGEN_DISABLED" or event == "PLAYER_REGEN_ENABLED" or event == "GROUP_ROSTER_UPDATE" then
+        if SLH.frame then
+            if SLH:IsEnabled() then
+                SLH.frame:Show()
+            else
+                SLH.frame:Hide()
+            end
         end
     end
 end)

--- a/SpectrumLootTool.toc
+++ b/SpectrumLootTool.toc
@@ -2,7 +2,7 @@
 ## Title: Spectrum Loot Helper
 ## Notes: Track Best-in-Slot rolls for Spectrum Federation
 ## Author: Spectrum Federation
-## Version: 0.1.3
+## Version: 0.1.4
 ## SavedVariables: SpectrumLootHelperDB
 
 Core.lua

--- a/UI.lua
+++ b/UI.lua
@@ -31,6 +31,13 @@ function SLH:CreateOptions()
     checkbox:SetChecked(self.db.settings.allowOutsideRaid)
     checkbox:SetScript("OnClick", function(btn)
         SLH.db.settings.allowOutsideRaid = btn:GetChecked()
+        if SLH.frame then
+            if SLH:IsEnabled() then
+                SLH.frame:Show()
+            else
+                SLH.frame:Hide()
+            end
+        end
     end)
 
     self.optionsPanel = panel


### PR DESCRIPTION
## Summary
- Instantiate the main frame on load and show or hide it based on combat and raid status
- Ensure the "Enable outside raid groups" setting immediately updates frame visibility
- Document conditional UI visibility in the changelog

## Testing
- `luacheck .` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease files are not signed)*
- `apt-get install -y lua5.1` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6897ee754cb88324b8431784f1978587