### PR TITLE
Fix solo roster display and refresh logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.6 - Solo roster display
+- UI now shows the player's own entry when not in a raid and the outside raid option is enabled.
+- Roster automatically refreshes when group membership or roll counts change.
+
 ## 0.1.5 - Movable frame
 - Frame position can be locked or unlocked and dragged around the screen.
 - Saved user-chosen frame position between sessions.

--- a/Core.lua
+++ b/Core.lua
@@ -1,6 +1,6 @@
 local ADDON_NAME, SLH = ...
 
-SLH.version = "0.1.5"
+SLH.version = "0.1.6"
 SLH.OFFICER_RANK = 2 -- configurable officer rank threshold
 
 -- Initialize saved variables and basic database
@@ -51,6 +51,9 @@ function SLH:AdjustRoll(playerName, delta, officer)
     if self.Sync then
         self.Sync:Broadcast()
     end
+    if self.frame then
+        self:UpdateRoster()
+    end
 end
 
 -- Event handling
@@ -64,6 +67,7 @@ frame:SetScript("OnEvent", function(_, event, arg1)
         SLH:Init()
         local f = SLH:CreateMainFrame()
         if SLH:IsEnabled() then f:Show() else f:Hide() end
+        if f:IsShown() then SLH:UpdateRoster() end
         print("|cff00ff00Spectrum Loot Helper loaded|r")
     elseif event == "PLAYER_REGEN_DISABLED" or event == "PLAYER_REGEN_ENABLED" or event == "GROUP_ROSTER_UPDATE" then
         if SLH.frame then
@@ -71,6 +75,9 @@ frame:SetScript("OnEvent", function(_, event, arg1)
                 SLH.frame:Show()
             else
                 SLH.frame:Hide()
+            end
+            if SLH.frame:IsShown() then
+                SLH:UpdateRoster()
             end
         end
     end
@@ -84,5 +91,10 @@ SlashCmdList["SPECTRUMLOOTHELPER"] = function()
         return
     end
     local f = SLH:CreateMainFrame()
-    if f:IsShown() then f:Hide() else f:Show() end
+    if f:IsShown() then
+        f:Hide()
+    else
+        f:Show()
+        SLH:UpdateRoster()
+    end
 end

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ directory contains the addon's `.toc` and Lua files.
 - Officer rank threshold can be edited in `Core.lua` via `OFFICER_RANK`.
 - Roll count changes automatically sync with other raid members.
 - In-game, open **Options > AddOns > Spectrum Loot Helper** and enable **Outside Raid** to use the addon while not in a raid group.
+- When enabled outside raids, the window still lists your character so you can monitor your own roll count while solo.
 - Unlock the frame in **Options > AddOns > Spectrum Loot Helper** to drag it to a preferred position. The addon remembers where you place it.
 
 ## Development

--- a/SpectrumLootTool.toc
+++ b/SpectrumLootTool.toc
@@ -2,7 +2,7 @@
 ## Title: Spectrum Loot Helper
 ## Notes: Track Best-in-Slot rolls for Spectrum Federation
 ## Author: Spectrum Federation
-## Version: 0.1.5
+## Version: 0.1.6
 ## SavedVariables: SpectrumLootHelperDB
 
 Core.lua

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,5 +3,6 @@
 Spectrum Loot Helper manages Best-in-Slot roll counts and keeps a synchronized log
 among Spectrum Federation guild members. Data changes broadcast to the raid so
 every member stays up to date. A settings toggle lets players use the addon
-outside raid groups if desired. Another option lets you unlock the frame and drag it
+outside raid groups if desired; when enabled, the UI still lists the current
+player even when solo. Another option lets you unlock the frame and drag it
 anywhere on the screen, with the position saved between sessions.


### PR DESCRIPTION
## Summary
- show player's own entry when outside raid groups
- refresh roster whenever group or roll data changes
- document solo display behavior

## Testing
- `luacheck *.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `mkdocs build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897f695a7488324930f9f75fb6dddcf