### PR TITLE
Add officer roll adjustment buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.7 - Officer adjustment buttons
+- Officers now have up and down arrow buttons to modify each player's roll count from the main UI.
+
 ## 0.1.6 - Solo roster display
 - UI now shows the player's own entry when not in a raid and the outside raid option is enabled.
 - Roster automatically refreshes when group membership or roll counts change.

--- a/Core.lua
+++ b/Core.lua
@@ -1,6 +1,6 @@
 local ADDON_NAME, SLH = ...
 
-SLH.version = "0.1.6"
+SLH.version = "0.1.7"
 SLH.OFFICER_RANK = 3 -- configurable officer rank threshold
 
 -- Initialize saved variables and basic database

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ directory contains the addon's `.toc` and Lua files.
 - Use `/slh` in-game to toggle the addon window.
 - Officer rank threshold can be edited in `Core.lua` via `OFFICER_RANK`.
 - Roll count changes automatically sync with other raid members.
+- Officers see arrow buttons next to each player to adjust roll counts.
 - In-game, open **Options > AddOns > Spectrum Loot Helper** and enable **Outside Raid** to use the addon while not in a raid group.
 - When enabled outside raids, the window still lists your character so you can monitor your own roll count while solo.
 - Unlock the frame in **Options > AddOns > Spectrum Loot Helper** to drag it to a preferred position. The addon remembers where you place it.

--- a/SpectrumLootTool.toc
+++ b/SpectrumLootTool.toc
@@ -2,7 +2,7 @@
 ## Title: Spectrum Loot Helper
 ## Notes: Track Best-in-Slot rolls for Spectrum Federation
 ## Author: Spectrum Federation
-## Version: 0.1.6
+## Version: 0.1.7
 ## SavedVariables: SpectrumLootHelperDB
 
 Core.lua

--- a/UI.lua
+++ b/UI.lua
@@ -73,14 +73,34 @@ function SLH:UpdateRoster()
             row:SetSize(180, 20)
             row.nameText = row:CreateFontString(nil, "OVERLAY", "GameFontNormal")
             row.nameText:SetPoint("LEFT")
+            row.upButton = CreateFrame("Button", nil, row, "UIPanelScrollUpButtonTemplate")
+            row.upButton:SetSize(16, 16)
+            row.upButton:SetPoint("RIGHT", row, "RIGHT", -2, 6)
+            row.downButton = CreateFrame("Button", nil, row, "UIPanelScrollDownButtonTemplate")
+            row.downButton:SetSize(16, 16)
+            row.downButton:SetPoint("RIGHT", row, "RIGHT", -2, -6)
             row.valueText = row:CreateFontString(nil, "OVERLAY", "GameFontNormal")
-            row.valueText:SetPoint("RIGHT")
+            row.valueText:SetPoint("RIGHT", row.upButton, "LEFT", -2, 0)
             frame.rows[i] = row
         end
         row:SetPoint("TOPLEFT", 10, -30 - (i - 1) * 20)
         local color = RAID_CLASS_COLORS[info.class] or { r = 1, g = 1, b = 1 }
         row.nameText:SetText(info.name)
         row.nameText:SetTextColor(color.r, color.g, color.b)
+        row.playerName = info.name
+        row.upButton:SetScript("OnClick", function()
+            SLH:AdjustRoll(row.playerName, 1, UnitName("player"))
+        end)
+        row.downButton:SetScript("OnClick", function()
+            SLH:AdjustRoll(row.playerName, -1, UnitName("player"))
+        end)
+        if SLH:IsOfficer("player") then
+            row.upButton:Show()
+            row.downButton:Show()
+        else
+            row.upButton:Hide()
+            row.downButton:Hide()
+        end
         row.valueText:SetText(SLH.db.rolls[info.name] or 0)
         row:Show()
     end

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,5 +4,6 @@ Spectrum Loot Helper manages Best-in-Slot roll counts and keeps a synchronized l
 among Spectrum Federation guild members. Data changes broadcast to the raid so
 every member stays up to date. A settings toggle lets players use the addon
 outside raid groups if desired; when enabled, the UI still lists the current
-player even when solo. Another option lets you unlock the frame and drag it
+player even when solo. Officers see arrow buttons on each row to increase or
+decrease roll counts. Another option lets you unlock the frame and drag it
 anywhere on the screen, with the position saved between sessions.


### PR DESCRIPTION
## Summary
- Show up/down arrow controls for each player row when the user is an officer
- Document officer adjustment buttons and bump addon version to 0.1.7

## Testing
- `lua -v` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6897f94a86988324a2d4d911f8eda1ee